### PR TITLE
Migrate to AGP 9 and upgrade dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,4 @@ org.gradle.caching=true
 #Android
 android.nonTransitiveRClass=true
 android.useAndroidX=true
+android.builtInKotlin=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,18 +1,18 @@
 [versions]
-agp = "8.13.2"
+agp = "9.0.1"
 android-compileSdk = "36"
 android-minSdk = "24"
 android-targetSdk = "36"
-androidx-activity = "1.12.2"
+androidx-activity = "1.12.4"
 androidx-appcompat = "1.7.1"
 androidx-core = "1.17.0"
 androidx-espresso = "3.7.0"
-androidx-lifecycle = "2.9.6"
+androidx-lifecycle = "2.10.0"
 androidx-testExt = "1.3.0"
 composeHotReload = "1.0.0"
 composeMultiplatform = "1.10.0"
 junit = "4.13.2"
-kotlin = "2.3.0"
+kotlin = "2.3.10"
 kotlinx-coroutines = "1.10.2"
 
 [libraries]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Migrates the project to AGP 9.0.1 and upgrades all dependency versions to their latest stable releases.

**Changes:**
- AGP 8.13.2 → 9.0.1
- Kotlin 2.3.0 → 2.3.10
- Gradle wrapper 8.14.3 → 9.3.1
- androidx-activity 1.12.2 → 1.12.4
- androidx-lifecycle (KMP) 2.9.6 → 2.10.0
- Added `android.builtInKotlin=false` to prevent KMP/AGP conflict

Closes #6

Generated with [Claude Code](https://claude.ai/code)